### PR TITLE
🐛 SassC::SyntaxError: Internal Error: Invalid UTF-8に対して🚮gem "dartsass…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,5 +86,3 @@ gem 'rails-i18n'
 
 # debug
 gem 'pry-rails'
-
-gem "dartsass-rails", "~> 0.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,9 +93,6 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.1.2)
       railties (>= 6.0.0)
-    dartsass-rails (0.5.0)
-      railties (>= 6.0.0)
-      sass-embedded (~> 1.63)
     date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
@@ -112,8 +109,6 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    google-protobuf (3.23.3-arm64-darwin)
-    google-protobuf (3.23.3-x86_64-linux)
     googleauth (1.5.2)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
@@ -219,10 +214,6 @@ GEM
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sass-embedded (1.63.6-arm64-darwin)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.63.6-x86_64-linux-gnu)
-      google-protobuf (~> 3.23)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -285,7 +276,6 @@ DEPENDENCIES
   capybara
   carrierwave (>= 3.0.0.beta, < 4.0)
   cssbundling-rails
-  dartsass-rails (~> 0.5.0)
   debug
   dotenv-rails
   googleauth


### PR DESCRIPTION
…-rails", "~> 0.5.0"