### PR TITLE
🐛FIX:syntax error, unexpected local variable or method, expecting }aw…

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -10,8 +10,8 @@ CarrierWave.configure do |config|
     config.fog_provider = 'fog/aws'
     config.fog_credentials = {
       provider: 'AWS',
-      aws_access_key_id: ENV['AWS_ACCESS_KEY']
-      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+      aws_access_key_id: ENV['AWS_ACCESS_KEY'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       region: 'ap-northeast-3' #アジアパシフィック（大阪）
     }
 


### PR DESCRIPTION
syntax error, unexpected local variable or method, expecting '}'
             aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']