### PR TITLE
🐛ctionView::Template::Error (The asset "top_bubble.js" is not present…

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -9,7 +9,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <script src="<%= asset_path('top_bubble.js') %>" defer="true"></script>
+    <%= javascript_include_tag asset_path('top_bubble.js'), defer: true %>
     <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
… in the asset pipeline.に対して<%= javascript_include_tag asset_path(top_bubble.js), defer: true %>に記載変更